### PR TITLE
Fixes #1 removing the dependency to "@types/zen-observable": "^0.8.0",

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -11,7 +11,6 @@
     "@types/react-dom": "^16.0.11",
     "@types/react-router-bootstrap": "^0.24.5",
     "@types/react-router-dom": "^4.3.1",
-    "@types/zen-observable": "^0.8.0",
     "aws-amplify": "^1.0.10",
     "bootstrap": "^3.3.7",
     "react": "^16.5.0",


### PR DESCRIPTION
*Issue #1*

*Description of changes:*
The dependency tree has two different versions of @types/zen-observable, this avoid the build process.
So, it's not necessary this lib on package.json.